### PR TITLE
Add exception handling

### DIFF
--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -1,10 +1,13 @@
-﻿using System;
+﻿
+using System.Runtime.InteropServices;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEngine;
+using VirtualMaze.Assets.Scripts.Utils;
 
 /// <summary>
 /// MonoBehaviour that affects VirtualMaze globally.
@@ -195,6 +198,9 @@ public class GameController : MonoBehaviour {
         while (sessions.Count > 0) {
             path = sessions.Dequeue();
             logger.Print($"Starting({count}/{total}): {path}");
+            generationComplete = false;
+ 
+
 
             StartCoroutine(ProcessWrapper(path + unityfileMatFile, path + eyelinkMatFile, path, mapper, logger));
             while (!generationComplete) {
@@ -207,6 +213,10 @@ public class GameController : MonoBehaviour {
                 }
             }
             if (File.Exists(path + resultFile)) {
+                if (saver.progressBar.value != 1) {
+                    logger.Print($"Exited but not finished, check debug logger for possible reason!");
+                    logger.Print($"Percentage completed : {saver.progressBar.value * 100}%");
+                }
                 logger.Print($"Success: {path + resultFile}");
             }
             else {
@@ -234,17 +244,15 @@ public class GameController : MonoBehaviour {
         print($"edf: {edfPath}");
         print($"toFolder: {toFolderPath}");
 
-        generationComplete = false;
+
+
+
         try {
-            IEnumerator psdtCoroutine = saver.ProcessSessionDataTask(sessionPath, edfPath, toFolderPath, mapper)
-            if (psdtCoroutine.value)
-                yield return psdtCoroutine;
-        } catch (Exception e) {
-            logger.Print(e.Message);
-            yield break;
+            yield return saver.ProcessSessionDataTask(sessionPath, edfPath, toFolderPath, mapper);
         }
         finally { //so that the batchmode app will quit or move on the the next session
             generationComplete = true;
         }
+
     }
 }

--- a/Assets/Scripts/ScreenSaver.cs
+++ b/Assets/Scripts/ScreenSaver.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Security.AccessControl;
+using System.Runtime.InteropServices;
 using Eyelink.Structs;
 using HDF.PInvoke;
 using System;
@@ -287,7 +288,7 @@ public class ScreenSaver : BasicGUIController {
         uint edfEventPeriod = LoadToNextTriggerEdf(eyeReader, fixations, out MessageEvent edfdata, out SessionTrigger edfTrigger);
 
         if (sessionData.trigger != edfTrigger) {
-            throw new Exception("Unaligned session and eyedata! Are there missing triggers in eyelink or Unity data?");
+            throw new System.IO.FileFormatException("Unaligned session and eyedata! Are there missing triggers in eyelink or Unity data?");
         }
 
         decimal excessTime = (sessionEventPeriod - edfEventPeriod);
@@ -324,7 +325,7 @@ public class ScreenSaver : BasicGUIController {
         }
     }
 
-    private IEnumerator ProcessSession(ISessionDataReader sessionReader, EyeDataReader eyeReader, RayCastRecorder recorder, BinRecorder binRecorder, BinMapper mapper) {
+    private IEnumerator ProcessSession(ISessionDataReader sessionReader, EyeDataReader eyeReader, RayCastRecorder recorder, BinRecorder binRecorder, BinMapper mapper, out string message) {
         int frameCounter = 0;
         int trialCounter = 1;
 

--- a/Assets/Scripts/ScreenSaver.cs
+++ b/Assets/Scripts/ScreenSaver.cs
@@ -288,7 +288,7 @@ public class ScreenSaver : BasicGUIController {
         uint edfEventPeriod = LoadToNextTriggerEdf(eyeReader, fixations, out MessageEvent edfdata, out SessionTrigger edfTrigger);
 
         if (sessionData.trigger != edfTrigger) {
-            throw new System.IO.FileFormatException("Unaligned session and eyedata! Are there missing triggers in eyelink or Unity data?");
+            throw new Exception("Unaligned session and eyedata! Are there missing triggers in eyelink or Unity data?");
         }
 
         decimal excessTime = (sessionEventPeriod - edfEventPeriod);
@@ -325,7 +325,7 @@ public class ScreenSaver : BasicGUIController {
         }
     }
 
-    private IEnumerator ProcessSession(ISessionDataReader sessionReader, EyeDataReader eyeReader, RayCastRecorder recorder, BinRecorder binRecorder, BinMapper mapper, out string message) {
+    private IEnumerator ProcessSession(ISessionDataReader sessionReader, EyeDataReader eyeReader, RayCastRecorder recorder, BinRecorder binRecorder, BinMapper mapper) {
         int frameCounter = 0;
         int trialCounter = 1;
 
@@ -356,9 +356,15 @@ public class ScreenSaver : BasicGUIController {
              * and the previous frame raised a trigger for it to be printed in this frame*/
 
             sessionFrames.Enqueue(sessionReader.CurrentData);
-
-            decimal excessTime = EnqueueData(sessionFrames, sessionReader, fixations, eyeReader, out int status, out string reason);
-
+            decimal excessTime = 0; 
+            // dummy because it's in a try-catch below
+            // decimal will always have a value fed to it, will break if try fails.
+            try {
+                excessTime = EnqueueData(sessionFrames, sessionReader, fixations, eyeReader, out int status, out string reason);
+            } catch (Exception e) {
+                
+                yield break;
+            } 
             decimal timepassed = fixations.Peek().time;
             decimal c1 = 0;
             decimal c2 = 0;

--- a/Assets/Scripts/ScreenSaver.cs
+++ b/Assets/Scripts/ScreenSaver.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.AccessControl;
+﻿using System.Diagnostics;
+using System.Security.AccessControl;
 using System.Runtime.InteropServices;
 using Eyelink.Structs;
 using HDF.PInvoke;
@@ -362,7 +363,7 @@ public class ScreenSaver : BasicGUIController {
             try {
                 excessTime = EnqueueData(sessionFrames, sessionReader, fixations, eyeReader, out int status, out string reason);
             } catch (Exception e) {
-                
+                Debug.LogException(e);
                 yield break;
             } 
             decimal timepassed = fixations.Peek().time;


### PR DESCRIPTION
Add exception handling to `ScreenSaver#ProcessSession`

`ProcessSession` calls `ScreenSaver#EnqueueData`, which can throw an `Exception` when it runs into an error in file format regarding misaligned triggers, namely `Unaligned session and eyedata! Are there missing triggers in eyelink or Unity data?`. 

This PR handles this `Exception` by wrapping `EnqueueData` in a `try-catch` block, stopping the coroutine & logging the above warning if the exception occurs.

Also, the program will check for if the generation actually completed or interrupted, printing a message to `VirtualMazeBatchLog.txt` if it was interrupted. See below for an example.

In practice, this will mean the application will exit (slightly more) gracefully when it runs into trigger errors in the dataset.

![image](https://github.com/TempReposBN/VirtualMaze/assets/54708640/3034992c-95b9-443c-88b1-3c5c67db9cc8)
